### PR TITLE
IRIS PDR-2: Updates required for TCS - IRIS ICD

### DIFF
--- a/iris/component-model.conf
+++ b/iris/component-model.conf
@@ -9,9 +9,9 @@ description = """
 The TCS provides telemetry streams to control several components of IRIS:
 
 * **OIWFS probe arms**: The three arms are continuously positioned over guide stars.
-* **4 ADCs**: One fore each OIWFS probe arm, and one for the imager.
+* **4 ADCs**: One for each OIWFS probe arm, and one for the science (for both Imager and IFS).
 * **rotator**: IRIS is rotated to compensate sidereal rotation and changes in pupil rotation, thus maintaining a stable scientific image.
-* **rotating cold-stop**: rotating stage that masks the pupil inside the imager.
+* **Cold Stop**: The cold stop masks out the thermal radiation from the telescope structure. The maskof the cold stop has to align with the telescope pupil. Because the instrument rotator compensates both sidereal rotation and pupil rotation, the cold stop rotary stage inside the instrument has to negate the rotation caused by sidereal rotation. The X/Y position of the mask has to be also adjusted depending on the instrument rotator angle to compensate the misalignment between the insturment rotator and the instrument optical path (TBD).
 """
 
 modelVersion = "1.1"  // version of model in use for component

--- a/iris/component-model.conf
+++ b/iris/component-model.conf
@@ -9,6 +9,7 @@ description = """
 The TCS provides telemetry streams to control several components of IRIS:
 
 * **OIWFS probe arms**: The three arms are continuously positioned over guide stars.
+* **ODGW positions**: Up to four on-detector guide windows are positioned over guide stars.
 * **4 ADCs**: One for each OIWFS probe arm, and one for the science (for both Imager and IFS).
 * **rotator**: IRIS is rotated to compensate sidereal rotation and changes in pupil rotation, thus maintaining a stable scientific image.
 * **Cold Stop**: The cold stop masks out the thermal radiation from the telescope structure. The mask of the cold stop has to align with the telescope pupil.

--- a/iris/component-model.conf
+++ b/iris/component-model.conf
@@ -11,7 +11,7 @@ The TCS provides telemetry streams to control several components of IRIS:
 * **OIWFS probe arms**: The three arms are continuously positioned over guide stars.
 * **4 ADCs**: One for each OIWFS probe arm, and one for the science (for both Imager and IFS).
 * **rotator**: IRIS is rotated to compensate sidereal rotation and changes in pupil rotation, thus maintaining a stable scientific image.
-* **Cold Stop**: The cold stop masks out the thermal radiation from the telescope structure. The maskof the cold stop has to align with the telescope pupil. Because the instrument rotator compensates both sidereal rotation and pupil rotation, the cold stop rotary stage inside the instrument has to negate the rotation caused by sidereal rotation. The X/Y position of the mask has to be also adjusted depending on the instrument rotator angle to compensate the misalignment between the insturment rotator and the instrument optical path (TBD).
+* **Cold Stop**: The cold stop masks out the thermal radiation from the telescope structure. The mask of the cold stop has to align with the telescope pupil.
 """
 
 modelVersion = "1.1"  // version of model in use for component

--- a/iris/component-model.conf
+++ b/iris/component-model.conf
@@ -11,9 +11,9 @@ The TCS provides telemetry streams to control several components of IRIS:
 * **OIWFS probe arms**: The three arms are continuously positioned over guide stars.
 * **4 ADCs**: One fore each OIWFS probe arm, and one for the imager.
 * **rotator**: IRIS is rotated to compensate sidereal rotation and changes in pupil rotation, thus maintaining a stable scientific image.
-*
+* **rotating cold-stop**: rotating stage that masks the pupil inside the imager.
 """
 
-modelVersion = "1.0"  // version of model in use for component
+modelVersion = "1.1"  // version of model in use for component
 wbsId = TMT.TCS.CM.IRIS
 

--- a/iris/publish-model.conf
+++ b/iris/publish-model.conf
@@ -439,8 +439,6 @@ publish {
       name              = pupilRotation
       description       = """
       The TCS publishes the timestamped current pupil rotation angle.
-
-      *Discussion: During LGS, NGS or seeing limited operations, the IRIS instrument rotator will correct for the combination of parallactic angle and pupil rotation, meaning that the pupil orientation will vary. The pupil mask rotators will need the current pupil rotation, likely after some linear transformation with constant coefficients, in order to keep a pupil mask aligned with the pupil image of the primary mirror.*
       """
       minRate           = 20
       maxRate           = 20

--- a/iris/publish-model.conf
+++ b/iris/publish-model.conf
@@ -5,63 +5,15 @@ publish {
 
   events          = [
     {
-      name              = parallacticAngle
-      description       = """
-      The TCS publishes the parallactic angle at the target telescope location.
-
-      **TBD**: The event must be issued 50 ms before the parallactic angle becomes valid considering the time for the event propagation over the network and additional latency caused by IRIS software and control system.
-      """
-      minRate           = 20
-      maxRate           = 20
-      archive           = true
-      attributes        = [
-        {
-          name          = parallacticAngle
-          description   = """
-          The parallactic angle at the target telescope location in the XY plane of the FCRS<sub>IRIS-ROT</sub>. The parallactic angle is the angle formed at a point on the sky between a great circle between the point and the zenith, and a great circle between the piont and the celestial pole.
-
-          This is the same as the zenith direction (the orientation of the axis of dispersion due to atmospheric refraction) in the FCRS<sub>IRIS-ROT</sub>
-
-           *Discussion: During LGS, NGS or seeing limited operations, the IRIS Imager ADC prism rotation angles are updated based on the Imager Atmospheric Dispersion data. This angle is used to align the ADC axis of correction along the axis of dispersion.*
-          """
-          type          = double
-          minimum       = -180
-          maximum       = 180
-          units         = degrees
-        }
-        {
-          name          = pointingstate
-          description   = """
-          Current state of the event stream
-
-          *Discussion: SLEWING and TRACKING are the two normal values expected during science observations. INPOSITION is a state only expected during the day when the telescope points at a fixed Az, El.*
-          """
-          enum          = [SLEWING,TRACKING,INPOSITION]
-        }      
-        {
-          name          = counter
-          description   = "Unique TCS target counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
-          type          = long
-        }
-        {
-          name          = timestamp
-          description   = """
-          Time when valid (units and epoch are TBD)
-
-          *Discussion: The accuracy of the timestamp shall be better than 100 us, which is the accuracy that software PTP daemon can achieve (ref.: [TMT Software Design Document (Volume 2 of 2) (TMT.SFT.TEC.12.016.REL05)](https://docushare.tmt.org/docushare/dsweb/Get/Document-24358)).*
-
-          *Discussion: Originally, the type was defined as "double", but now it is "long" (64-bit integer). The significand part of double value has 52 bits, which means it has effectively 53 bits precision. Assuming that the resolution of this timestamp is microsecond (e.g. gettimeofday() function returns the current time in microsecond resolution), and assuming the epoch is 1858-11-17 12:00:00 UT (MJD), a single double variable can count the time until year 2143 (=~ 1858 + 2^53 / 365 / 24 / 60 / 60 / 1000 / 1000) in microsecond resolution. After that, the time resolution will be worse. This is probably OK considering TMT lifetime, but the operation system normally reports the time as an integer value(s) anyway. TCS does not have to convert it to double which has less precision than 64-bit integer.*
-          """
-          units         = mjd
-          type          = long
-        }
-      ]
-    }
-    {
       name              = imgAtmDispersion
       description       = """
        The TCS publishes the IRIS imager dispersion information at the target telescope location.
+
        The entire event is published atomically so that all published subcomponents are synchronized.
+
+       *Discussion: For sidereal tracking, the maximum rotation velocity of ADC prisms caused by the orientation change (= the change rate of the parallactic angle) is 0.225 deg/s, which happens when observing a target that transits 1 degree south from the zenith. The current required position accuracy is [+/- 0.28 deg](https://docushare.tmt.org/docushare/dsweb/Get/Document-57487/DN%20IRIS.IMG.ADC_REL01.pdf), so 1 Hz of update rate should be enough. If IRIS will need finer time granuality to frequently control the mechanisms, IRIS software should perform interpolation internally using the new event and the past events. If we really need to increase the update rate of this event in the future for better accuracy, there are two options: increase the update rate of this telemetry, or split "orientation" attribute into a separate event because the rotation velocity caused by the atmospheric correction is likely to be much slower than the velocity caused by the orientation change.*
+
+       *Discussion: It is expected that this event is published two ticks (= 2 seconds in case the update rate of this event is 1 Hz) before the time indicated by "timestamp" attribute. This event shall be published, at least, one tick before the time indicated by "timestamp" attribute to allow IRIS to perform interpolation of "orientation". Considering the calculation time to perform interpolation and margin for communication & software delay, it should be one more tick before, hence two ticks in total.*
        """
       minRate           = 1
       maxRate           = 1
@@ -78,6 +30,19 @@ publish {
           minimum       = 0.5
           maximum       = 3.0
           units         = microns
+        }
+        {
+          name          = orientation
+          description   = """Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of the FCRS<sub>IRIS-ROT</sub>.
+
+          *Discussion: For conventional field rotation tracking observations, this value will be the same as the parallactic angle (or its negative). This is because the ADC is inside the instrument, and the angle of the instrument rotator is a combination of parallactic angle and pupil rotation. The ADC just needs to negate the parallactic angle caused by the insturment rotator. This value may include an offset if the observer has requested a particular zenith direction in the image.*
+
+          *Discussion:  If we need to support pupil rotation tracking mode (= fixed pupil mode, or ADI mode) in the future, this value should be the zenith direction in the image specified by the observer. This should be fixed during the observation because the instrument rotator is supposed to compensate the pupil rotation.*
+"""
+          type          = double
+          minimum       = -180
+          maximum       = 180
+          units         = degrees
         }
         {
           name          = wavelength
@@ -438,7 +403,9 @@ publish {
     {
       name              = pupilRotation
       description       = """
-      The TCS publishes the timestamped current pupil rotation angle.
+      The TCS publishes the timestamped future pupil rotation angle.
+
+      **TBD**: This event shall be issued 50 ms before the time indicated by "timestamp" attribute considering the time for the event propagation over the network and additional latency caused by IRIS software and control system.
       """
       minRate           = 20
       maxRate           = 20
@@ -446,9 +413,14 @@ publish {
       attributes        = [
         {
           name          = pupilRotation
-          description   = "Current IRIS pupil rotation angle in the X,Y plane of the FCRS<sub>IRIS-ROT</sub>."
+          description   = """Future IRIS pupil rotation angle in the X,Y plane of the FCRS<sub>IRIS-ROT</sub> that will be valid at the time indicated by "timestamp" attribute.
+
+          *Discussion: For conventional field rotation tracking observations, this value will be the same as the parallactic angle (or its negative). This is because the cold stop is inside the instrument, and the angle of the instrument rotator is a combination of parallactic angle and pupil rotation. The cold stop just needs to negate the parallactic angle caused by the insturment rotator. This value may include an offset if the observer has requested a particular zenith direction in the image.*
+
+          *Discussion:  If we need to support pupil rotation tracking mode (= fixed pupil mode, or ADI mode) in the future, this value should be the zenith direction in the image specified by the observer. This should be fixed during the observation because the instrument rotator is supposed to compensate the pupil rotation.*
+"""
           type          = double
-          minimum       = 90
+          minimum       = -180
           maximum       = 180
           units         = degrees
         }

--- a/iris/publish-model.conf
+++ b/iris/publish-model.conf
@@ -414,12 +414,6 @@ publish {
           units         = degrees
         }
         {
-          name          = pupilRotationTimestamp
-          description   = "Associated timestamp (units TBD)"
-          type          = double
-          units         = mjd
-        }
-        {
           name          = pointingstate
           description   = "Current state of the event stream"
           enum          = [SLEWING,TRACKING,INPOSITION]

--- a/iris/publish-model.conf
+++ b/iris/publish-model.conf
@@ -8,6 +8,8 @@ publish {
       name              = parallacticAngle
       description       = """
       The TCS publishes the parallactic angle at the target telescope location.
+
+      **TBD**: The event must be issued 50 ms before the parallactic angle becomes valid considering the time for the event propagation over the network and additional latency caused by IRIS software and control system.
       """
       minRate           = 20
       maxRate           = 20

--- a/iris/publish-model.conf
+++ b/iris/publish-model.conf
@@ -5,6 +5,51 @@ publish {
 
   events          = [
     {
+      name              = parallacticAngle
+      description       = """
+      The TCS publishes the parallactic angle at the target telescope location.
+      """
+      minRate           = 20
+      maxRate           = 20
+      archive           = true
+      attributes        = [
+        {
+          name          = parallacticAngle
+          description   = """
+          The parallactic angle at the target telescope location in the XY plane of the FCRS<sub>IRIS-ROT</sub>. The parallactic angle is the angle formed at a point on the sky between a great circle between the point and the zenith, and a great circle between the piont and the celestial pole.
+
+          This is the same as the zenith direction (the orientation of the axis of dispersion due to atmospheric refraction) in the FCRS<sub>IRIS-ROT</sub>
+
+           *Discussion: During LGS, NGS or seeing limited operations, the IRIS Imager ADC prism rotation angles are updated based on the Imager Atmospheric Dispersion data. This angle is used to align the ADC axis of correction along the axis of dispersion.*
+          """
+          type          = double
+          minimum       = -180
+          maximum       = 180
+          units         = degrees
+        }
+        {
+          name          = pointingstate
+          description   = """
+          Current state of the event stream
+
+          *Discussion: SLEWING and TRACKING are the two normal values expected during science observations. INPOSITION is a state only expected during the day when the telescope points at a fixed Az, El.*
+          """
+          enum          = [SLEWING,TRACKING,INPOSITION]
+        }      
+        {
+          name          = counter
+          description   = "Unique TCS target counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
+          type          = long
+        }
+        {
+          name          = timestamp
+          description   = "Time when valid (units TBD)"
+          units         = mjd
+          type          = double
+        }
+      ]
+    }
+    {
       name              = imgAtmDispersion
       description       = """
        The TCS publishes the IRIS imager dispersion information at the target telescope location.
@@ -25,18 +70,6 @@ publish {
           minimum       = 0.5
           maximum       = 3.0
           units         = microns
-        }
-        {
-          name          = orientation
-          description   = """
-          Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of the FCRS<sub>IRIS-ROT</sub>.
-
-           *Discussion: During LGS, NGS or seeing limited operations, the IRIS Imager ADC prism rotation angles are updated based on the Imager Atmospheric Dispersion data. The orientation angle is used to align the ADC axis of correction along the axis of dispersion.*
-          """
-          type          = double
-          minimum       = -180
-          maximum       = 180
-          units         = degrees
         }
         {
           name          = wavelength

--- a/iris/publish-model.conf
+++ b/iris/publish-model.conf
@@ -3,11 +3,11 @@ component               = cmIRIS
 
 publish {
 
-  telemetry          = [
+  events          = [
     {
-      name              = imgCurAtmDispersion
+      name              = imgAtmDispersion
       description       = """
-       The TCS publishes the IRIS imager dispersion information at the current telescope location.
+       The TCS publishes the IRIS imager dispersion information at the target telescope location.
        The entire event is published atomically so that all published subcomponents are synchronized.
        """
       minRate           = 1
@@ -39,22 +39,11 @@ publish {
           units         = degrees
         }
         {
-          name          = numElem
-          description   = """
-          Number of entries (each) in the wavelengths, weights and dispersion elements. Range is TBC.
-
-          *Discussion: The numElem field represents the number of distinct wavelengths of dispersion information. The wavelength, weight and dispersion arrays each contain exactly numElem values. It is expected that the number of elements is large enough to provide the general shape of the dispersion over the required wavelength range. In a simplified mode of operation at which a specific setting of the ADC is desired for correction at a particular wavelength, numElem will be 1.*
-          """
-          type          = integer
-          minimum       = 1
-          maximum       = 30
-        }
-        {
           name          = wavelength
           description   = """
           An array of wavelengths. Each provided wavelength value must be unique. Range is TBC.
 
-          *Discussion: The wavelength field represents the distinct wavelengths for which dispersion information is provided by the TCS. It is TBD whether the TCS will provide the same range of wavelengths for all ADC control or whether each ADC would only receive a restricted range of wavelengths based on the range of light that it would be correcting. The number of wavelength values provided must be exactly equal to the value of numElem. In a simplified mode of operation at which a specific setting of the ADC is desired for correction at a particular wavelength, only that wavelength will be specified.*
+          *Discussion: The wavelength field represents the distinct wavelengths for which dispersion information is provided by the TCS. It is TBD whether the TCS will provide the same range of wavelengths for all ADC control or whether each ADC would only receive a restricted range of wavelengths based on the range of light that it would be correcting. In a simplified mode of operation at which a specific setting of the ADC is desired for correction at a particular wavelength, only that wavelength will be specified.*
           """
           type          = array
           minItems      = 1
@@ -71,7 +60,7 @@ publish {
           description   = """
           An array of weights. They must sum to 1.0.
 
-          *Discussion: The weight field represents a weighting function to be applied to the dispersion curve; this weighting function from the TCS may include telescope throughput and source spectral energy distribution, although it is TBD whether all of these components are combined into this single function, or whether it is pieced together from several locations. This weight will not contain information local to the imager, such as the selected filter and detector quantum efficient. The number of weight values provided must be exactly equal to the value of numElem. Each weight must be non-negative and the sum of the weights is normalized to unity.*
+          *Discussion: The weight field represents a weighting function to be applied to the dispersion curve; this weighting function from the TCS may include telescope throughput and source spectral energy distribution, although it is TBD whether all of these components are combined into this single function, or whether it is pieced together from several locations. This weight will not contain information local to the imager, such as the selected filter and detector quantum efficient. Each weight must be non-negative and the sum of the weights is normalized to unity.*
 
           """
           type          = array
@@ -88,7 +77,7 @@ publish {
           description   = """
           An array of atmospheric dispersion values.
 
-          *Discussion: The dispersion field is the calculated relative atmospheric dispersion at each wavelength after subtracting a reference dispersion at the reference wavelength. The dispersion is measured in arcseconds on the sky. The number of dispersion values provided must be exactly equal to the value of numElem. The IRIS CC will use the atmospheric dispersion values along with the weights and wavelengths to determine a power setting for the ADC.*
+          *Discussion: The dispersion field is the calculated relative atmospheric dispersion at each wavelength after subtracting a reference dispersion at the reference wavelength. The dispersion is measured in arcseconds on the sky. The IRIS CC will use the atmospheric dispersion values along with the weights and wavelengths to determine a power setting for the ADC.*
           """
           type          = array
           minItems      = 1
@@ -98,96 +87,35 @@ publish {
             type        = double
           }
         }
-      ]
-    }
+        {
+          name          = pointingstate
+          description   = """
+          Current state of the event stream
 
-    {
-      name              = imgNewAtmDispersion
-      description       = """
-      The TCS publishes a single new IRIS Imager Dispersion event each time a new target is to be acquired.
-      Information is pertinent to the new target location.
-
-      *Discussion: The ADC should adjust to the values indicated by tcs.cm.iris.imgNewAtmDispersion until a tcs.cm.iris.pointingStatus event is published with state set to Tracking, and the same counter value. At that point, it should switch back to tracking imgCurAtmDispersion.*
-
-      *Discussion: See full descriptions of equivalent attributes in imgCurAtmDispersion*
-      """
-      archive           = true
-      attributes        = [
-        {
-          name          = referenceWavelength
-          description   = "The reference wavelength is the wavelength at which the computed dispersion is reported by the TCS as 0. Range is TBC."
-          type          = double
-          minimum       = 0.5
-          maximum       = 3.0
-          units         = microns
-        }
-        {
-          name          = orientation
-          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of FCRS<sub>IRIS-ROT</sub>."
-          type          = double
-          minimum       = -180
-          maximum       = 180
-          units         = degrees
-        }
-        {
-          name          = numElem
-          description   = "Number of entries (each) in the wavelengths, weights and dispersion elements. Range is TBC."
-          type          = integer
-          minimum       = 1
-          maximum       = 30
-        }
-        {
-          name          = wavelength
-          description   = "An array of wavelengths. Each provided wavelength value must be unique. Range is TBC (0.6 to 0.8 if restricted to NGS path)."
-          type          = array
-          minItems      = 1
-          maxItems      = 30
-          minimum       = 0.5
-          maximum       = 3.0
-          units         = microns
-          items         = {
-            type        = double
-          }
-        }
-        {
-          name          = weight
-          description   = "An array of weights. They must sum to 1.0."
-          type          = array
-          minItems      = 1
-          maxItems      = 30
-          minimum       = 0.0
-          maximum       = 1.0
-          items         = {
-            type        = double
-          }
-        }
-        {
-          name          = dispersion
-          description   = "An array of atmospheric dispersion values."
-          type          = array
-          minItems      = 1
-          maxItems      = 30
-          units         = arcsec on sky
-          items         = {
-            type        = double
-          }
-        }
+          *Discussion: SLEWING and TRACKING are the two normal values expected during science observations. INPOSITION is a state only expected during the day when the telescope points at a fixed Az, El.*
+          """
+          enum          = [SLEWING,TRACKING,INPOSITION]
+        }      
         {
           name          = counter
-          description   = "Unique TCS counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
+          description   = "Unique TCS target counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
           type          = long
+        }
+        {
+          name          = timestamp
+          description   = "Time when valid (units TBD)"
+          units         = mjd
+          type          = double
         }
       ]
     }
 
-
-
     {
-      name              = oiwfs1CurAtmDispersion
+      name              = oiwfs1AtmDispersion
       description       = """
-       The TCS publishes the IRIS OIWFS dispersion information (one for each probe) at the current telescope location.
+       The TCS publishes the IRIS OIWFS dispersion information (one for each probe) at the target telescope location.
 
-      *Discussion: See full descriptions of equivalent attributes in imgCurAtmDispersion*
+      *Discussion: See full descriptions of equivalent attributes in imgAtmDispersion*
        """
       minRate           = 1
       maxRate           = 1
@@ -208,13 +136,6 @@ publish {
           minimum       = -180
           maximum       = 180
           units         = degrees
-        }
-        {
-          name          = numElem
-          description   = "Number of entries (each) in the wavelengths, weights and dispersion elements. Range is TBC"
-          type          = integer
-          minimum       = 1
-          maximum       = 30
         }
         {
           name          = wavelength
@@ -252,94 +173,31 @@ publish {
             type        = double
           }
         }
-      ]
-    }
-
-    {
-      name              = oiwfs1NewAtmDispersion
-      description       = """
-      The TCS publishes single new IRIS OIWFS Dispersion events (one for each probe) each time a new target is to be acquired.
-      Information is pertinent to the new target location.
-
-      *Discussion: Each probe arm ADC should adjust to the values indicated by the correct tcs.cm.iris.oiwfsXNewAtmDispersion until the relevant tcs.cm.iris.oiwfsXpointingStatus event is published, with state set to Tracking, and the same counter value. At that point, it should switch back to tracking oiwfs1CurAtmDispersion. Note that each arm requires its own pointingStatus stream to enable subsets of the probes to acquire new stars while the remaining probes continue tracking.*
-
-      *Discussion: See full descriptions of equivalent attributes in imgCurAtmDispersion*
-      """
-      archive           = true
-      attributes        = [
         {
-          name          = referenceWavelength
-          description   = "The reference wavelength is the wavelength at which the computed dispersion is reported by the TCS as 0. Range is TBC."
-          type          = double
-          minimum       = 0.5
-          maximum       = 3.0
-          units         = microns
-        }
-        {
-          name          = orientation
-          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of FCRS<sub>IRIS-ROT</sub>."
-          type          = double
-          minimum       = -180
-          maximum       = 180
-          units         = degrees
-        }
-        {
-          name          = numElem
-          description   = "Number of entries (each) in the wavelengths, weights and dispersion elements. Range is TBC."
-          type          = integer
-          minimum       = 1
-          maximum       = 30
-        }
-        {
-          name          = wavelength
-          description   = "An array of wavelengths. Each provided wavelength value must be unique. Range is TBC (0.6 to 0.8 if restricted to NGS path)."
-          type          = array
-          minItems      = 1
-          maxItems      = 30
-          minimum       = 0.5
-          maximum       = 3.0
-          units         = microns
-          items         = {
-            type        = double
-          }
-        }
-        {
-          name          = weight
-          description   = "An array of weights. They must sum to 1.0."
-          type          = array
-          minItems      = 1
-          maxItems      = 30
-          minimum       = 0.0
-          maximum       = 1.0
-          items         = {
-            type        = double
-          }
-        }
-        {
-          name          = dispersion
-          description   = "An array of atmospheric dispersion values."
-          type          = array
-          minItems      = 1
-          maxItems      = 30
-          units         = arcsec on sky
-          items         = {
-            type        = double
-          }
-        }
+          name          = pointingstate
+          description   = "Current state of the event stream"
+          enum          = [SLEWING,TRACKING,INPOSITION]
+        }      
         {
           name          = counter
-          description   = "Unique TCS counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
+          description   = "Unique TCS target counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
           type          = long
+        }
+        {
+          name          = timestamp
+          description   = "Time when valid (units TBD)"
+          units         = mjd
+          type          = double
         }
       ]
     }
 
     {
-      name              = oiwfs2CurAtmDispersion
+      name              = oiwfs2AtmDispersion
       description       = """
-      The TCS publishes the IRIS OIWFS dispersion information (one for each probe) at the current telescope location.
+       The TCS publishes the IRIS OIWFS dispersion information (one for each probe) at the target telescope location.
 
-      *Discussion: See full descriptions of equivalent attributes in imgCurAtmDispersion*
+      *Discussion: See full descriptions of equivalent attributes in imgAtmDispersion*
        """
       minRate           = 1
       maxRate           = 1
@@ -360,13 +218,6 @@ publish {
           minimum       = -180
           maximum       = 180
           units         = degrees
-        }
-        {
-          name          = numElem
-          description   = "Number of entries (each) in the wavelengths, weights and dispersion elements. Range is TBC"
-          type          = integer
-          minimum       = 1
-          maximum       = 30
         }
         {
           name          = wavelength
@@ -404,93 +255,31 @@ publish {
             type        = double
           }
         }
-      ]
-    }
-
-    {
-      name              = oiwfs2NewAtmDispersion
-      description       = """
-      The TCS publishes single new IRIS OIWFS Dispersion events (one for each probe) each time a new target is to be acquired.
-      Information is pertinent to the new target location.
-
-      *Discussion: See full descriptions of equivalent attributes in imgCurAtmDispersion and oiwfs1NewAtmDispersion*
-      """
-      archive           = true
-      attributes        = [
         {
-          name          = referenceWavelength
-          description   = "The reference wavelength is the wavelength at which the computed dispersion is reported by the TCS as 0. Range is TBC."
-          type          = double
-          minimum       = 0.5
-          maximum       = 3.0
-          units         = microns
-        }
-        {
-          name          = orientation
-          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of FCRS<sub>IRIS-ROT</sub>."
-          type          = double
-          minimum       = -180
-          maximum       = 180
-          units         = degrees
-        }
-        {
-          name          = numElem
-          description   = "Number of entries (each) in the wavelengths, weights and dispersion elements. Range is TBC."
-          type          = integer
-          minimum       = 1
-          maximum       = 30
-        }
-        {
-          name          = wavelength
-          description   = "An array of wavelengths. Each provided wavelength value must be unique. Range is TBC (0.6 to 0.8 if restricted to NGS path)."
-          type          = array
-          minItems      = 1
-          maxItems      = 30
-          minimum       = 0.5
-          maximum       = 3.0
-          units         = microns
-          items         = {
-            type        = double
-          }
-        }
-        {
-          name          = weight
-          description   = "An array of weights. They must sum to 1.0."
-          type          = array
-          minItems      = 1
-          maxItems      = 30
-          minimum       = 0.0
-          maximum       = 1.0
-          items         = {
-            type        = double
-          }
-        }
-        {
-          name          = dispersion
-          description   = "An array of atmospheric dispersion values."
-          type          = array
-          minItems      = 1
-          maxItems      = 30
-          units         = arcsec on sky
-          items         = {
-            type        = double
-          }
-        }
+          name          = pointingstate
+          description   = "Current state of the event stream"
+          enum          = [SLEWING,TRACKING,INPOSITION]
+        }      
         {
           name          = counter
-          description   = "Unique TCS counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
+          description   = "Unique TCS target counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
           type          = long
+        }
+        {
+          name          = timestamp
+          description   = "Time when valid (units TBD)"
+          units         = mjd
+          type          = double
         }
       ]
     }
 
-
     {
-      name              = oiwfs3CurAtmDispersion
+      name              = oiwfs3AtmDispersion
       description       = """
-       The TCS publishes the IRIS OIWFS dispersion information (one for each probe) at the current telescope location.
+       The TCS publishes the IRIS OIWFS dispersion information (one for each probe) at the target telescope location.
 
-      *Discussion: See full descriptions of equivalent attributes in imgCurAtmDispersion*
+      *Discussion: See full descriptions of equivalent attributes in imgAtmDispersion*
        """
       minRate           = 1
       maxRate           = 1
@@ -511,13 +300,6 @@ publish {
           minimum       = -180
           maximum       = 180
           units         = degrees
-        }
-        {
-          name          = numElem
-          description   = "Number of entries (each) in the wavelengths, weights and dispersion elements. Range is TBC"
-          type          = integer
-          minimum       = 1
-          maximum       = 30
         }
         {
           name          = wavelength
@@ -555,148 +337,21 @@ publish {
             type        = double
           }
         }
-      ]
-    }
-
-    {
-      name              = oiwfs3NewAtmDispersion
-      description       = """
-      The TCS publishes single new IRIS OIWFS Dispersion events (one for each probe) each time a new target is to be acquired.
-      Information is pertinent to the new target location.
-
-      *Discussion: See full descriptions of equivalent attributes in imgCurAtmDispersion and oiwfs1NewAtmDispersion*
-      """
-      archive           = true
-      attributes        = [
         {
-          name          = referenceWavelength
-          description   = "The reference wavelength is the wavelength at which the computed dispersion is reported by the TCS as 0. Range is TBC."
+          name          = pointingstate
+          description   = "Current state of the event stream"
+          enum          = [SLEWING,TRACKING,INPOSITION]
+        }      
+        {
+          name          = counter
+          description   = "Unique TCS target counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
+          type          = long
+        }
+        {
+          name          = timestamp
+          description   = "Time when valid (units TBD)"
+          units         = mjd
           type          = double
-          minimum       = 0.5
-          maximum       = 3.0
-          units         = microns
-        }
-        {
-          name          = orientation
-          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of FCRS<sub>IRIS-ROT</sub>."
-          type          = double
-          minimum       = -180
-          maximum       = 180
-          units         = degrees
-        }
-        {
-          name          = numElem
-          description   = "Number of entries (each) in the wavelengths, weights and dispersion elements. Range is TBC."
-          type          = integer
-          minimum       = 1
-          maximum       = 30
-        }
-        {
-          name          = wavelength
-          description   = "An array of wavelengths. Each provided wavelength value must be unique. Range is TBC (0.6 to 0.8 if restricted to NGS path)."
-          type          = array
-          minItems      = 1
-          maxItems      = 30
-          minimum       = 0.5
-          maximum       = 3.0
-          units         = microns
-          items         = {
-            type        = double
-          }
-        }
-        {
-          name          = weight
-          description   = "An array of weights. They must sum to 1.0."
-          type          = array
-          minItems      = 1
-          maxItems      = 30
-          minimum       = 0.0
-          maximum       = 1.0
-          items         = {
-            type        = double
-          }
-        }
-        {
-          name          = dispersion
-          description   = "An array of atmospheric dispersion values."
-          type          = array
-          minItems      = 1
-          maxItems      = 30
-          units         = arcsec on sky
-          items         = {
-            type        = double
-          }
-        }
-        {
-          name          = counter
-          description   = "Unique TCS counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
-          type          = long
-        }
-      ]
-    }
-
-    {
-      name              = oiwfs1pointingStatus
-      description       = """
-      The TCS publishes current pointing status events for each OIWFS probe arm independently, each time the state changes.
-
-      *Discussion: See full descriptions of equivalent attributes in tcs.pk.pointingStatus.*
-      """
-      archive           = true
-      attributes        = [
-        {
-          name          = state
-          description   = "Current state of the pointing system"
-          enum          = [Slewing,Tracking,InPosition]
-        }
-        {
-          name          = counter
-          description   = "Current target counter (incrementing with rollover)"
-          type          = long
-        }
-      ]
-    }
-
-    {
-      name              = oiwfs2pointingStatus
-      description       = """
-      The TCS publishes current pointing status events for each OIWFS probe arm independently, each time the state changes.
-
-      *Discussion: See full descriptions of equivalent attributes in tcs.pk.pointingStatus.*
-      """
-      archive           = true
-      attributes        = [
-        {
-          name          = state
-          description   = "Current state of the pointing system"
-          enum          = [Slewing,Tracking,InPosition]
-        }
-        {
-          name          = counter
-          description   = "Current target counter (incrementing with rollover)"
-          type          = long
-        }
-      ]
-    }
-
-    {
-      name              = oiwfs3pointingStatus
-      description       = """
-      The TCS publishes current pointing status events for each OIWFS probe arm independently, each time the state changes.
-
-      *Discussion: See full descriptions of equivalent attributes in tcs.pk.pointingStatus.*
-      """
-      archive           = true
-      attributes        = [
-        {
-          name          = state
-          description   = "Current state of the pointing system"
-          enum          = [Slewing,Tracking,InPosition]
-        }
-        {
-          name          = counter
-          description   = "Current target counter (incrementing with rollover)"
-          type          = long
         }
       ]
     }
@@ -714,17 +369,27 @@ publish {
       attributes        = [
         {
           name          = instrumentAngle
-          description   = "Current rotator angle in the XY plane of the FCRS<sub>BP</sub>."
+          description   = "Current rotator angle in the XY plane of the FCRS<sub>IRIS</sub>."
           type          = double
           minimum       = -135
           maximum       = 135
           units         = degrees
         }
         {
-          name          = instrumentAngleTimestamp
-          description   = "Associated timestamp (units TBD)"
-          type          = double
+          name          = pointingstate
+          description   = "Current state of the event stream"
+          enum          = [SLEWING,TRACKING,INPOSITION]
+        }      
+        {
+          name          = counter
+          description   = "Unique TCS target counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
+          type          = long
+        }
+        {
+          name          = timestamp
+          description   = "Time when valid (units TBD)"
           units         = mjd
+          type          = double
         }
       ]
     }
@@ -754,22 +419,38 @@ publish {
           type          = double
           units         = mjd
         }
+        {
+          name          = pointingstate
+          description   = "Current state of the event stream"
+          enum          = [SLEWING,TRACKING,INPOSITION]
+        }      
+        {
+          name          = counter
+          description   = "Unique TCS target counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
+          type          = long
+        }
+        {
+          name          = timestamp
+          description   = "Time when valid (units TBD)"
+          units         = mjd
+          type          = double
+        }
       ]
     }
 
     {
       name              = oiwfsProbeDemands
       description       = """
-      The TCS publishes the timestamped focal plane locations and velocities for each IRIS OIWFS at some TBD time in the future.
+      The TCS publishes the timestamped focal plane locations for each IRIS OIWFS at some TBD time in the future.
 
-      *Discussion: During an observation, the TCS will provide the timestamped XY locations and velocities of the OIWFS sensors in the focal plane so that each OIWFS can accurately track its guide star.*
+      *Discussion: During an observation, the TCS will provide the timestamped XY locations of the OIWFS sensors in the focal plane so that each OIWFS can accurately track its guide star. All probe positions published atomically to improve synchronization.*
       """
       minRate           = 20
       maxRate           = 20
       archive           = true
       attributes        = [
         {
-          name          = oiwfs1Pos
+          name          = oiwfs1_pos
           description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
           type          = array
           dimensions: [2]
@@ -779,7 +460,7 @@ publish {
           }
         }
         {
-          name          = oiwfs2Pos
+          name          = oiwfs2_pos
           description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
           type          = array
           dimensions: [2]
@@ -789,7 +470,7 @@ publish {
           }
         }
         {
-          name          = oiwfs3Pos
+          name          = oiwfs3_pos
           description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
           type          = array
           dimensions: [2]
@@ -799,38 +480,38 @@ publish {
           }
         }
         {
-          name          = oiwfs1Vel
-          description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
-          type          = array
-          dimensions: [2]
-          units = mm/s
-          items = {
-            type = double
-          }
+          name          = oiwfs1_pointingstate
+          description   = "Current state of the probe event stream"
+          enum          = [SLEWING,TRACKING,INPOSITION]
+        }      
+        {
+          name          = oiwfs1_counter
+          description   = "Unique TCS target counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
+          type          = long
         }
         {
-          name          = oiwfs2Vel
-          description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
-          type          = array
-          dimensions: [2]
-          units = mm/s
-          items = {
-            type = double
-          }
+          name          = oiwfs2_pointingstate
+          description   = "Current state of the probe event stream"
+          enum          = [SLEWING,TRACKING,INPOSITION]
+        }      
+        {
+          name          = oiwfs2_counter
+          description   = "Unique TCS target counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
+          type          = long
         }
         {
-          name          = oiwfs3Vel
-          description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
-          type          = array
-          dimensions: [2]
-          units = mm/s
-          items = {
-            type = double
-          }
+          name          = oiwfs3_pointingstate
+          description   = "Current state of the probe event stream"
+          enum          = [SLEWING,TRACKING,INPOSITION]
+        }      
+        {
+          name          = oiwfs3_counter
+          description   = "Unique TCS target counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
+          type          = long
         }
         {
-          name          = oiwfsPositionTimestamp
-          description   = "Timestamp these are applicable (units TBD)"
+          name          = timestamp
+          description   = "Time when valid (units TBD)"
           type          = double
           units         = mjd
         }
@@ -842,14 +523,14 @@ publish {
       description       = """
       The TCS publishes the timestamped focal plane locations for each IRIS ODGW at some TBD time in the future.
 
-      *During an observation, the TCS will provide the timestamped XY locations of the guide stars for ODGWs. Velocities are not required, as in the case of the OIWFS position streams, since window locations can be changed instantaneously.*
+      *During an observation, the TCS will provide the timestamped XY locations of the guide stars for ODGWs.*
       """
       minRate           = 20
       maxRate           = 20
       archive           = true
       attributes        = [
         {
-          name          = odgw1Pos
+          name          = odgw1_pos
           description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
           type          = array
           dimensions: [2]
@@ -859,7 +540,7 @@ publish {
           }
         }
         {
-          name          = odgw2Pos
+          name          = odgw2_pos
           description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
           type          = array
           dimensions: [2]
@@ -869,7 +550,7 @@ publish {
           }
         }
         {
-          name          = odgw3Pos
+          name          = odgw3_pos
           description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
           type          = array
           dimensions: [2]
@@ -879,7 +560,7 @@ publish {
           }
         }
         {
-          name          = odgw4Pos
+          name          = odgw4_pos
           description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
           type          = array
           dimensions: [2]
@@ -889,8 +570,48 @@ publish {
           }
         }
         {
-          name          = odgwPositionTimestamp
-          description   = "Timestamp these are applicable (units TBD)"
+          name          = odgw1_pointingstate
+          description   = "Current state of the ODGW event stream"
+          enum          = [SLEWING,TRACKING,INPOSITION]
+        }      
+        {
+          name          = odgw1_counter
+          description   = "Unique TCS target counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
+          type          = long
+        }
+        {
+          name          = odgw2_pointingstate
+          description   = "Current state of the ODGW event stream"
+          enum          = [SLEWING,TRACKING,INPOSITION]
+        }      
+        {
+          name          = odgw2_counter
+          description   = "Unique TCS target counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
+          type          = long
+        }
+        {
+          name          = odgw3_pointingstate
+          description   = "Current state of the ODGW event stream"
+          enum          = [SLEWING,TRACKING,INPOSITION]
+        }      
+        {
+          name          = odgw3_counter
+          description   = "Unique TCS target counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
+          type          = long
+        }
+        {
+          name          = odgw4_pointingstate
+          description   = "Current state of the ODGW event stream"
+          enum          = [SLEWING,TRACKING,INPOSITION]
+        }      
+        {
+          name          = odgw4_counter
+          description   = "Unique TCS target counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
+          type          = long
+        }        
+        {
+          name          = timestamp
+          description   = "Time when valid (units TBD)"
           type          = double
           units         = mjd
         }

--- a/iris/publish-model.conf
+++ b/iris/publish-model.conf
@@ -43,9 +43,15 @@ publish {
         }
         {
           name          = timestamp
-          description   = "Time when valid (units TBD)"
+          description   = """
+          Time when valid (units and epoch are TBD)
+
+          *Discussion: The accuracy of the timestamp shall be better than 100 us, which is the accuracy that software PTP daemon can achieve (ref.: [TMT Software Design Document (Volume 2 of 2) (TMT.SFT.TEC.12.016.REL05)](https://docushare.tmt.org/docushare/dsweb/Get/Document-24358)).*
+
+          *Discussion: Originally, the type was defined as "double", but now it is "long" (64-bit integer). The significand part of double value has 52 bits, which means it has effectively 53 bits precision. Assuming that the resolution of this timestamp is microsecond (e.g. gettimeofday() function returns the current time in microsecond resolution), and assuming the epoch is 1858-11-17 12:00:00 UT (MJD), a single double variable can count the time until year 2143 (=~ 1858 + 2^53 / 365 / 24 / 60 / 60 / 1000 / 1000) in microsecond resolution. After that, the time resolution will be worse. This is probably OK considering TMT lifetime, but the operation system normally reports the time as an integer value(s) anyway. TCS does not have to convert it to double which has less precision than 64-bit integer.*
+          """
           units         = mjd
-          type          = double
+          type          = long
         }
       ]
     }
@@ -136,9 +142,9 @@ publish {
         }
         {
           name          = timestamp
-          description   = "Time when valid (units TBD)"
+          description   = "Time when valid (units and epoch are TBD)"
           units         = mjd
-          type          = double
+          type          = long
         }
       ]
     }
@@ -218,9 +224,9 @@ publish {
         }
         {
           name          = timestamp
-          description   = "Time when valid (units TBD)"
+          description   = "Time when valid (units and epoch are TBD)"
           units         = mjd
-          type          = double
+          type          = long
         }
       ]
     }
@@ -300,9 +306,9 @@ publish {
         }
         {
           name          = timestamp
-          description   = "Time when valid (units TBD)"
+          description   = "Time when valid (units and epoch are TBD)"
           units         = mjd
-          type          = double
+          type          = long
         }
       ]
     }
@@ -382,9 +388,9 @@ publish {
         }
         {
           name          = timestamp
-          description   = "Time when valid (units TBD)"
+          description   = "Time when valid (units and epoch are TBD)"
           units         = mjd
-          type          = double
+          type          = long
         }
       ]
     }
@@ -420,9 +426,9 @@ publish {
         }
         {
           name          = timestamp
-          description   = "Time when valid (units TBD)"
+          description   = "Time when valid (units and epoch are TBD)"
           units         = mjd
-          type          = double
+          type          = long
         }
       ]
     }
@@ -458,9 +464,9 @@ publish {
         }
         {
           name          = timestamp
-          description   = "Time when valid (units TBD)"
+          description   = "Time when valid (units and epoch are TBD)"
           units         = mjd
-          type          = double
+          type          = long
         }
       ]
     }
@@ -538,9 +544,9 @@ publish {
         }
         {
           name          = timestamp
-          description   = "Time when valid (units TBD)"
+          description   = "Time when valid (units and epoch are TBD)"
           type          = double
-          units         = mjd
+          units         = long
         }
       ]
     }
@@ -638,9 +644,9 @@ publish {
         }        
         {
           name          = timestamp
-          description   = "Time when valid (units TBD)"
-          type          = double
+          description   = "Time when valid (units and epoch are TBD)"
           units         = mjd
+          type          = long
         }
       ]
     }

--- a/iris/subscribe-model.conf
+++ b/iris/subscribe-model.conf
@@ -2,7 +2,27 @@ subsystem = TCS
 component = cmIRIS
 
 subscribe {
-          telemetry = [
+          events = [
+          {
+          subsystem = IRIS
+          component = oiwfs-adc-assembly
+          name = oiwfsShift
+          }
+          {
+          subsystem = IRIS
+          component = oiwfs-adc-assembly
+          name = state
+          }
+          {
+          subsystem = IRIS
+          component = oiwfs-adc-assembly
+          name = target
+          }
+          {
+          subsystem = IRIS
+          component = oiwfs-adc-assembly
+          name = current
+          }
           {
           subsystem = IRIS
           component = oiwfs-poa-assembly
@@ -20,27 +40,53 @@ subscribe {
           }
           {
           subsystem = IRIS
-          component = oiwfs-adc-assembly
+          component = sci-adc-assembly
+          name = odgwShift
+          }
+          {
+          subsystem = IRIS
+          component = sci-adc-assembly
+          name = PRISM_state
+          }
+          {
+          subsystem = IRIS
+          component = sci-adc-assembly
+          name = PRISM_target
+          }
+          {
+          subsystem = IRIS
+          component = sci-adc-assembly
+          name = PRISM_current
+          }
+          {
+          subsystem = IRIS
+          component = imager-odgw-assembly
           name = state
+          }
+          {
+          subsystem = IRIS
+          component = imager-odgw-assembly
+          name = target
+          }
+          {
+          subsystem = IRIS
+          component = imager-odgw-assembly
+          name = current
           }
           {
           subsystem = IRIS
           component = rotator-assembly
           name = state
           }
-          ]
-
-          events = [
           {
           subsystem = IRIS
-          component = sci-adc-assembly
-          name = odgwShift
+          component = rotator-assembly
+          name = target
           }
           {
           subsystem = IRIS
-          component = oiwfs-adc-assembly
-          name = oiwfsShift
+          component = rotator-assembly
+          name = current
           }
-
           ]
 }

--- a/iris/subscribe-model.conf
+++ b/iris/subscribe-model.conf
@@ -5,6 +5,34 @@ subscribe {
           telemetry = [
           {
           subsystem = IRIS
+          component = oiwfs-poa-assembly
+          name = pos_state
+          }
+          {
+          subsystem = IRIS
+          component = oiwfs-poa-assembly
+          name = pos_target
+          }
+          {
+          subsystem = IRIS
+          component = oiwfs-poa-assembly
+          name = pos_current
+          }
+          {
+          subsystem = IRIS
+          component = oiwfs-adc-assembly
+          name = state
+          }
+          {
+          subsystem = IRIS
+          component = rotator-assembly
+          name = state
+          }
+          ]
+
+          events = [
+          {
+          subsystem = IRIS
           component = sci-adc-assembly
           name = odgwShift
           }
@@ -13,5 +41,6 @@ subscribe {
           component = oiwfs-adc-assembly
           name = oiwfsShift
           }
+
           ]
 }

--- a/iris/subscribe-model.conf
+++ b/iris/subscribe-model.conf
@@ -26,17 +26,17 @@ subscribe {
           {
           subsystem = IRIS
           component = oiwfs-poa-assembly
-          name = pos_state
+          name = POS_state
           }
           {
           subsystem = IRIS
           component = oiwfs-poa-assembly
-          name = pos_target
+          name = POS_target
           }
           {
           subsystem = IRIS
           component = oiwfs-poa-assembly
-          name = pos_current
+          name = POS_current
           }
           {
           subsystem = IRIS


### PR DESCRIPTION
This is a sister PR to https://github.com/tmt-icd/IRIS-Model-Files/pull/16 .

Highlights:
 - Merge the old TCS new/current/pointingstatus streams into a single stream.
 - Dropped the "number of elements" attribute from the ADC dispersion demands since this can easily be determined by checking the resulting vector length in the Java code
 - The datum (or index) substates of state.move have been moved down to the HCD layer from assemblies (so state.move just has MOVING | STOPPED).
 - Publish target and current streams. Target should contain a counter if one is provided by the TCS. The TCS can then subscribe to state/target/current if it wants to see whether a mechanism is currently tracking the intended target.
 - Every kind of event/telemetry that is involved in control decisions should use the Event Service. For now we assume that this even applies to state since sequencers will likely use this information.