### PR TITLE
nfiraos: Use taiDate for time stamps

### DIFF
--- a/nfiraos/publish-model.conf
+++ b/nfiraos/publish-model.conf
@@ -102,7 +102,7 @@ publish {
         {
           name          = timestamp
           description   = "Timestamp for the data"
-          type          = double
+          type          = taiDate
           units         = "TAI / PTP"
         }
       ]
@@ -152,7 +152,7 @@ publish {
         {
           name          = timestamp
           description   = "Timestamp for the data"
-          type          = double
+          type          = taiDate
           units         = "TAI / PTP"
         }
       ]
@@ -191,7 +191,7 @@ publish {
         {
           name          = timestamp
           description   = "Timestamp for the data"
-          type          = double
+          type          = taiDate
           units         = "TAI / PTP"
         }
       ]
@@ -237,7 +237,7 @@ publish {
         {
           name          = timestamp
           description   = "Timestamp for the data"
-          type          = double
+          type          = taiDate
           units         = "TAI / PTP"
         }
       ]


### PR DESCRIPTION
I'm not sure if this local change was made in response to an NCC FDR RIX, but at any rate it's something that should be updated.