### PR TITLE
Updates to TCS-IRIS ICD for IRIS FDR

### DIFF
--- a/iris/publish-model.conf
+++ b/iris/publish-model.conf
@@ -481,68 +481,36 @@ publish {
       archive           = true
       attributes        = [
         {
-          name          = oiwfs1_pos
-          description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
+          name          = oiwfs_pos
+          description   = "3x2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub> for each of the three probes."
           type          = array
-          dimensions: [2]
+          dimensions: [3,2]
           units = mm
           items = {
             type = double
           }
         }
         {
-          name          = oiwfs2_pos
-          description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
+          name          = oiwfs_pointingstate
+          description   = "3-element array holding current states of the three probe event stream."
           type          = array
-          dimensions: [2]
-          units = mm
+          dimensions: [3]
           items = {
-            type = double
+            enum          = [SLEWING,TRACKING,INPOSITION]
           }
-        }
+        }      
         {
-          name          = oiwfs3_pos
-          description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
+          name          = oiwfs_trackID
+          description   = "3-element array holding unique TCS target IDs for the three probes, each of which is incremented (with rollover) each time the TCS is instructed to move the window to a new target."
           type          = array
-          dimensions: [2]
-          units = mm
+          dimensions: [3]
           items = {
-            type = double
+            type          = long
           }
-        }
-        {
-          name          = oiwfs1_pointingstate
-          description   = "Current state of the probe event stream"
-          enum          = [SLEWING,TRACKING,INPOSITION]
-        }      
-        {
-          name          = oiwfs1_trackID
-          description   = "Unique TCS target ID that is incremented (with rollover) each time the TCS is instructed to move to a new target."
-          type          = long
-        }
-        {
-          name          = oiwfs2_pointingstate
-          description   = "Current state of the probe event stream"
-          enum          = [SLEWING,TRACKING,INPOSITION]
-        }      
-        {
-          name          = oiwfs2_trackID
-          description   = "Unique TCS target ID that is incremented (with rollover) each time the TCS is instructed to move to a new target."
-          type          = long
-        }
-        {
-          name          = oiwfs3_pointingstate
-          description   = "Current state of the probe event stream"
-          enum          = [SLEWING,TRACKING,INPOSITION]
-        }      
-        {
-          name          = oiwfs3_trackID
-          description   = "Unique TCS target ID that is incremented (with rollover) each time the TCS is instructed to move to a new target."
-          type          = long
         }
         {
           name          = timestamp
-          description   = "Time when valid (units and epoch are TBD)"
+          description   = "Time when valid (units and epoch are TBD)."
           type          = double
           units         = long
         }
@@ -554,91 +522,43 @@ publish {
       description       = """
       The TCS publishes the timestamped focal plane locations for each IRIS ODGW at some TBD time in the future.
 
-      *During an observation, the TCS will provide the timestamped XY locations of the guide stars for ODGWs.*
+      <em>
+      Discussion: During an observation, the TCS will provide the timestamped XY locations of the guide stars for ODGWs.
+
+      Discussion: At present the TCS will publish at most four ODGW positions. However, there is also a possibility that the TCS will generate positions for an additional set of Readout Windows that are repeatedly read-out on the IRIS imager in order to avoid saturation and long-term transient calibration issues. In that case, they could be added to this event, or provided as a separate event (TBD).
+      </em>
       """
       minRate           = 20
       maxRate           = 20
       archive           = true
       attributes        = [
         {
-          name          = odgw1_pos
-          description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
+          name          = odgw_pos
+          description   = "4x2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub> for each of the four ODGWs."
           type          = array
-          dimensions: [2]
+          dimensions: [4,2]
           units = mm
           items = {
             type = double
           }
         }
         {
-          name          = odgw2_pos
-          description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
+          name          = odgw_pointingstate
+          description   = "4-element array holding current states of the ODGW event stream."
           type          = array
-          dimensions: [2]
-          units = mm
+          dimensions: [4]
           items = {
-            type = double
+            enum          = [SLEWING,TRACKING,INPOSITION]
           }
-        }
+        }      
         {
-          name          = odgw3_pos
-          description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
+          name          = odgw_trackID
+          description   = "4-element array holding unique TCS target IDs that are incremented (with rollover) each time the TCS is instructed to move a window to a new target."
           type          = array
-          dimensions: [2]
-          units = mm
+          dimensions: [4]
           items = {
-            type = double
+            type          = long
           }
-        }
-        {
-          name          = odgw4_pos
-          description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
-          type          = array
-          dimensions: [2]
-          units = mm
-          items = {
-            type = double
-          }
-        }
-        {
-          name          = odgw1_pointingstate
-          description   = "Current state of the ODGW event stream"
-          enum          = [SLEWING,TRACKING,INPOSITION]
-        }      
-        {
-          name          = odgw1_trackID
-          description   = "Unique TCS target ID that is incremented (with rollover) each time the TCS is instructed to move to a new target."
-          type          = long
-        }
-        {
-          name          = odgw2_pointingstate
-          description   = "Current state of the ODGW event stream"
-          enum          = [SLEWING,TRACKING,INPOSITION]
-        }      
-        {
-          name          = odgw2_trackID
-          description   = "Unique TCS target ID that is incremented (with rollover) each time the TCS is instructed to move to a new target."
-          type          = long
-        }
-        {
-          name          = odgw3_pointingstate
-          description   = "Current state of the ODGW event stream"
-          enum          = [SLEWING,TRACKING,INPOSITION]
-        }      
-        {
-          name          = odgw3_trackID
-          description   = "Unique TCS target ID that is incremented (with rollover) each time the TCS is instructed to move to a new target."
-          type          = long
-        }
-        {
-          name          = odgw4_pointingstate
-          description   = "Current state of the ODGW event stream"
-          enum          = [SLEWING,TRACKING,INPOSITION]
-        }      
-        {
-          name          = odgw4_trackID
-          description   = "Unique TCS target ID that is incremented (with rollover) each time the TCS is instructed to move to a new target."
-          type          = long
         }        
         {
           name          = timestamp

--- a/iris/subscribe-model.conf
+++ b/iris/subscribe-model.conf
@@ -46,6 +46,11 @@ subscribe {
           {
           subsystem = IRIS
           component = sci-adc-assembly
+          name = sciShift
+          }
+          {
+          subsystem = IRIS
+          component = sci-adc-assembly
           name = PRISM_state
           }
           {


### PR DESCRIPTION
Main changes include switching to arrays where possible for wavefront sensor demands, and subscribing to the science target shift induced by the IRIS science ADC.

See sister PR: https://github.com/tmtsoftware/IRIS-Model-Files/pull/54