### PR TITLE
iris: update component names

### DIFF
--- a/iris/subscribe-model.conf
+++ b/iris/subscribe-model.conf
@@ -5,92 +5,92 @@ subscribe {
           events = [
           {
           subsystem = IRIS
-          component = oiwfs-adc-assembly
+          component = oiwfs.adc
           name = oiwfsShift
           }
           {
           subsystem = IRIS
-          component = oiwfs-adc-assembly
+          component = oiwfs.adc
           name = state
           }
           {
           subsystem = IRIS
-          component = oiwfs-adc-assembly
+          component = oiwfs.adc
           name = target
           }
           {
           subsystem = IRIS
-          component = oiwfs-adc-assembly
+          component = oiwfs.adc
           name = current
           }
           {
           subsystem = IRIS
-          component = oiwfs-poa-assembly
+          component = oiwfs.poa
           name = POS_state
           }
           {
           subsystem = IRIS
-          component = oiwfs-poa-assembly
+          component = oiwfs.poa
           name = POS_target
           }
           {
           subsystem = IRIS
-          component = oiwfs-poa-assembly
+          component = oiwfs.poa
           name = POS_current
           }
           {
           subsystem = IRIS
-          component = sci-adc-assembly
+          component = imager.adc
           name = odgwShift
           }
           {
           subsystem = IRIS
-          component = sci-adc-assembly
+          component = imager.adc
           name = sciShift
           }
           {
           subsystem = IRIS
-          component = sci-adc-assembly
+          component = imager.adc
           name = PRISM_state
           }
           {
           subsystem = IRIS
-          component = sci-adc-assembly
+          component = imager.adc
           name = PRISM_target
           }
           {
           subsystem = IRIS
-          component = sci-adc-assembly
+          component = imager.adc
           name = PRISM_current
           }
           {
           subsystem = IRIS
-          component = imager-odgw-assembly
+          component = imager.odgw
           name = state
           }
           {
           subsystem = IRIS
-          component = imager-odgw-assembly
+          component = imager.odgw
           name = target
           }
           {
           subsystem = IRIS
-          component = imager-odgw-assembly
+          component = imager.odgw
           name = current
           }
           {
           subsystem = IRIS
-          component = rotator-assembly
+          component = rotator
           name = state
           }
           {
           subsystem = IRIS
-          component = rotator-assembly
+          component = rotator
           name = target
           }
           {
           subsystem = IRIS
-          component = rotator-assembly
+          component = rotator
           name = current
           }
           ]


### PR DESCRIPTION
This PR updates the names of a bunch of IRIS assemblies so that they match recent updates that were part of the IRIS upgrade to schema 2.0 model files.