### PR TITLE
change name of demand stream ngsPos -> vnwPos for consistency

### DIFF
--- a/nfiraos/publish-model.conf
+++ b/nfiraos/publish-model.conf
@@ -108,9 +108,9 @@ publish {
     }
 
     {
-      name              = ngsPos
+      name              = vnwPos
       description       = """
-      NFIRAOS visible NGS image position demand. This stream will adjust the SSM to position the image on the PWFS
+      NFIRAOS Visible Natural Guide Star Wavefront Sensor image position demand. This stream will adjust the SSM to position the image on the VNW WFS.
 
       *Discussion: While SLEWING (including dithering) this position demand will be based on the telescope's target position. While INPOSITION or TRACKING this position demand will be based on the telescope's current position*
 
@@ -161,7 +161,7 @@ publish {
       description       = """
       Error in NFIRAOS visible NGS image position demands derived from the telescope mount encoders.
 
-      *Discussion: This error is relative to ngsPos (regardless of the pointingstate).*
+      *Discussion: This error is relative to vnwPos (regardless of the pointingstate).*
 
       *Discussion: This error should be published as soon as it is measured, which implies that its timestamp will generally be in the past (compared to when the event is received).*
       """


### PR DESCRIPTION
A while backup there was a general name change in the NFIRAOS model files for ngs -> vnw. This PR is for consistency.