### PR TITLE
Chapine/iris drs update

### DIFF
--- a/iris/publish-model.conf
+++ b/iris/publish-model.conf
@@ -560,6 +560,61 @@ publish {
       ]
     }
 
+    {
+      name              = oiwfsGuideStarLUT
+      description       = """
+      Lookup table used to determine which guide star metadata from
+      the PK guideStarInfo event pertain to the three OIWFS. For example,
+      the name, RA, and Dec of the target star for the first probe are
+      guideStarInfo.name[lut[0]], guideStarInfo.RA[lut[0]], and
+      guideStarInfo.Dec[lut[0]], where lut is the attribute contained in this
+      event.
+
+      Any WFS that is not in use will have its entry in lut set to -1.
+      """
+      maxRate           = 0.1
+      archive           = true
+      attributes        = [
+        {
+          name          = lut
+          description   = "Index into guideStarInfo for each of the three OIWFS"
+          type          = array
+          dimensions: [3]
+          items = {
+            type = integer
+          }
+        }
+      ]
+    }
+
+    {
+      name              = odgwGuideStarLUT
+      description       = """
+      Lookup table used to determine which guide star metadata from
+      the PK guideStarInfo event pertain to the four ODGW. For example,
+      the name, RA, and Dec of the target star for the first ODGW are
+      guideStarInfo.name[lut[0]], guideStarInfo.RA[lut[0]], and
+      guideStarInfo.Dec[lut[0]], where lut is the attribute contained in this
+      event.
+
+      Any WFS that is not in use will have its entry in lut set to -1.
+      """
+      maxRate           = 0.1
+      archive           = true
+      attributes        = [
+        {
+          name          = lut
+          description   = "Index into guideStarInfo for each of the four ODGW"
+          type          = array
+          dimensions: [4]
+          items = {
+            type = integer
+          }
+        }
+      ]
+    }
+
+    
   ]
 
 }

--- a/nfiraos/publish-model.conf
+++ b/nfiraos/publish-model.conf
@@ -238,5 +238,28 @@ publish {
         }
       ]
     }
+
+    {
+      name              = pwfsGuideStarLUT
+      description       = """
+      Lookup table to determine which guide star metadata from
+      the PK guideStarInfo event pertains to the PWFS. For example,
+      the name, RA, and Dec of the target star for the PWFS are
+      guideStarInfo.name[lut, guideStarInfo.RA[lut, and
+      guideStarInfo.Dec[lut, where lut is the attribute contained in this
+      event.
+
+      If the PWFS is not in use lut will be set to -1.
+      """
+      maxRate           = 0.1
+      archive           = true
+      attributes        = [
+        {
+          name          = lut
+          description   = "Index into guideStarInfo for the PWFS"
+          type          = integer
+        }
+      ]
+    }
   ]
 }

--- a/nfiraos/publish-model.conf
+++ b/nfiraos/publish-model.conf
@@ -240,23 +240,23 @@ publish {
     }
 
     {
-      name              = pwfsGuideStarLUT
+      name              = vnwGuideStarLUT
       description       = """
       Lookup table to determine which guide star metadata from
-      the PK guideStarInfo event pertains to the PWFS. For example,
-      the name, RA, and Dec of the target star for the PWFS are
-      guideStarInfo.name[lut, guideStarInfo.RA[lut, and
-      guideStarInfo.Dec[lut, where lut is the attribute contained in this
+      the PK guideStarInfo event pertains to the VNW. For example,
+      the name, RA, and Dec of the target star for the VNW are
+      guideStarInfo.name[lut], guideStarInfo.RA[lut], and
+      guideStarInfo.Dec[lut], where lut is the attribute contained in this
       event.
 
-      If the PWFS is not in use lut will be set to -1.
+      If the VNW is not in use lut will be set to -1.
       """
       maxRate           = 0.1
       archive           = true
       attributes        = [
         {
           name          = lut
-          description   = "Index into guideStarInfo for the PWFS"
+          description   = "Index into guideStarInfo for the VNW"
           type          = integer
         }
       ]

--- a/pk/publish-model.conf
+++ b/pk/publish-model.conf
@@ -167,6 +167,103 @@ publish {
       ]
     }
 
+    {
+      name              = guideStarInfo
+      description       = """
+      The TCS publishes metadata for all guide stars currently in use by the
+      telescope and instruments, including the name, ICRS RA and Dec,
+      proper motion, and color.
+
+      Indvidual TCS modules will publish a lookup table indicating which guide
+      stars from this table pertain to a particular mechanism or instrument.
+      
+      <em>
+      Discussion: It is not presently known whether guide star colors will
+      be provided with homogenized units. As a possible solution to this
+      problem the colorDescription array attribute is proposed, in which
+      the system and units of the color may be described.
+
+      Discussion: It is unknown how many guide stars the TCS will need to
+      support in total. The initial size of the arrays (10) has been chosen
+      to support slightly more than the maximum number of guide stars that might
+      be used by NFIRAOS (one PWFS) and IRIS (three OIWFS, and four ODGW).
+      </em>
+      
+      """
+      maxRate           = 0.1
+      archive           = true
+      attributes        = [
+        {
+          name          = name
+          description   = "Target name"
+          type          = array
+          dimensions: [10]
+          items = {
+            type = string
+          }
+        }
+        {
+          name          = RA
+          description   = "Right Ascension (ICRS)"
+          type          = array
+          dimensions: [10]
+          units = deg
+          items = {
+            type = double
+          }
+        }
+        {
+          name          = Dec
+          description   = "Declination (ICRS)"
+          type          = array
+          dimensions: [10]
+          units = deg
+          items = {
+            type = double
+          }
+        }
+        {
+          name          = ProperMotionRA
+          description   = "Proper motion in +ve RA direction (ICRS)"
+          type          = array
+          dimensions: [10]
+          units = milliarcsec / year
+          items = {
+            type = double
+          }
+        }
+        {
+          name          = ProperMotionDec
+          description   = "Proper motion in +ve Dec direction (ICRS)"
+          type          = array
+          dimensions: [10]
+          units = milliarcsec / year
+          items = {
+            type = double
+          }
+        }
+        {
+          name          = color
+          description   = "color"
+          type          = array
+          dimensions: [10]
+          items = {
+            type = double
+          }
+        }
+        {
+          name          = colorDescription
+          description   = "description of the color system / units"
+          type          = array
+          dimensions: [10]
+          items = {
+            type = string
+          }
+        }
+      ]
+    }
+
+
   ]
 
 }


### PR DESCRIPTION
This is a proposal to provide metadata on guide stars from the TCS. I believe this is along the lines of what we discussed (a master table of guide star information, and then per-subsystem lookup tables describing which elements of the master table pertain to specific WFS). I think this covers everything that the IRIS DRS team is interested in.

Feel free to comment / propose changes. 