### PR TITLE
Support for additional IRIS tracking modes

### DIFF
--- a/iris/publish-model.conf
+++ b/iris/publish-model.conf
@@ -439,6 +439,32 @@ publish {
     }
 
     {
+      name              = pupilRotation
+      description       = """
+      The TCS publishes the timestamped future pupil rotation angle.
+      """
+      maxRate           = 20
+      archive           = true
+      attributes        = [
+        {
+          name          = pupilRotation
+          description   = """Future IRIS pupil rotation angle in the X,Y plane of the FCRS<sub>IRIS-ROT</sub> that will be valid at the time indicated bythe "timestamp" attribute.
+"""
+          type          = double
+          minimum       = -180
+          maximum       = 180
+          units         = degrees
+        }
+        {
+          name          = timestamp
+          description   = "Time when valid (units and epoch are TBD)"
+          units         = mjd
+          type          = long
+        }
+      ]
+    }
+
+    {
       name              = positionAngle
       description       = """
       The TCS publishes the timestamped IRIS instrument position angle.

--- a/iris/publish-model.conf
+++ b/iris/publish-model.conf
@@ -11,11 +11,12 @@ publish {
 
        The entire event is published atomically so that all published subcomponents are synchronized.
 
-       *Discussion: For sidereal tracking, the maximum rotation velocity of ADC prisms caused by the orientation change (= the change rate of the parallactic angle) is 0.225 deg/s, which happens when observing a target that transits 1 degree south from the zenith. The current required position accuracy is [+/- 0.28 deg](https://docushare.tmt.org/docushare/dsweb/Get/Document-57487/DN%20IRIS.IMG.ADC_REL01.pdf), so 1 Hz of update rate should be enough. If IRIS will need finer time granuality to frequently control the mechanisms, IRIS software should perform interpolation internally using the new event and the past events. If we really need to increase the update rate of this event in the future for better accuracy, there are two options: increase the update rate of this telemetry, or split "orientation" attribute into a separate event because the rotation velocity caused by the atmospheric correction is likely to be much slower than the velocity caused by the orientation change.*
+       *Discussion: This event is published at 1 Hz. If IRIS needs finer time granuality to frequently control the mechanisms in their control loops, IRIS software should perform interpolation internally using the latest event and/or the past events.*
 
-       *Discussion: It is expected that this event is published two ticks (= 2 seconds in case the update rate of this event is 1 Hz) before the time indicated by "timestamp" attribute. This event shall be published, at least, one tick before the time indicated by "timestamp" attribute to allow IRIS to perform interpolation of "orientation". Considering the calculation time to perform interpolation and margin for communication & software delay, it should be one more tick before, hence two ticks in total.*
+       *Discussion: This event should be published nominally 3 seconds (and, at least, 2 seconds) before the time indicated by the "timestamp" attribute.*
        """
       maxRate           = 1
+      minRate           = 1
       archive           = true
       attributes        = [
         {
@@ -34,9 +35,7 @@ publish {
           name          = orientation
           description   = """Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of the FCRS<sub>IRIS-ROT</sub>.
 
-          *Discussion: For conventional field rotation tracking observations, this value will be the same as the parallactic angle (or its negative). This is because the ADC is inside the instrument, and the angle of the instrument rotator is a combination of parallactic angle and pupil rotation. The ADC just needs to negate the parallactic angle caused by the insturment rotator. This value may include an offset if the observer has requested a particular zenith direction in the image.*
-
-          *Discussion:  If we need to support pupil rotation tracking mode (= fixed pupil mode, or ADI mode) in the future, this value should be the zenith direction in the image specified by the observer. This should be fixed during the observation because the instrument rotator is supposed to compensate the pupil rotation.*
+          *Discussion: For conventional field rotation tracking observations, this value is the same as the parallactic angle (or its negative) plus the position angle. However, this attribute can be just the position angle or the sum of the pupil rotation and the position angle in different tracking modes. See "2.1.2 IRIS Celestial Tracking Modes" in TMT.SEN.ICD.13.002 for more details.*
 """
           type          = double
           minimum       = -180
@@ -364,6 +363,8 @@ publish {
       The TCS publishes the timestamped current IRIS instrument rotator angle.
 
       *Discussion: During LGS, NGS or seeing limited operations, the IRIS instrument rotator will rotate to derotate the field, which rotates as the telescope tracks a target across the sky (a combination of parallactic angle and pupil rotation). In addition, the rotator angle may include an offset if the observer has requested a particular PA.*
+
+      *Discussion: In the M1 tracking mode, this angle excludes the parallactic angle to tranck only M1 so that there is a fixed M1 pupil pattern in the IRIS focal plane. In the DM0 tracking mode, this angle only includes the position angle specified by the observer so that the rotator is static. See "2.1.2 IRIS Celestial Tracking Modes" in TMT.SEN.ICD.13.002 for more details.*
       """
       minRate           = 25
       maxRate           = 100
@@ -397,22 +398,21 @@ publish {
     }
 
     {
-      name              = pupilRotation
+      name              = coldStopMaskAngle
       description       = """
-      The TCS publishes the timestamped future pupil rotation angle.
+      The TCS publishes the timestamped future cold stop mask angle.
 
-      **TBD**: This event shall be issued 50 ms before the time indicated by "timestamp" attribute considering the time for the event propagation over the network and additional latency caused by IRIS software and control system.
+       *Discussion: This event should be published nominally 3 seconds (and, at least, 2 seconds) before the time indicated by the "timestamp" attribute.*
       """
+      minRate           = 10
       maxRate           = 20
       archive           = true
       attributes        = [
         {
-          name          = pupilRotation
-          description   = """Future IRIS pupil rotation angle in the X,Y plane of the FCRS<sub>IRIS-ROT</sub> that will be valid at the time indicated by "timestamp" attribute.
+          name          = coldStopMaskAngle
+          description   = """Future IRIS pupil rotation angle in the X,Y plane of the FCRS<sub>IRIS-ROT</sub> that will be valid at the time indicated bythe "timestamp" attribute.
 
-          *Discussion: For conventional field rotation tracking observations, this value will be the same as the parallactic angle (or its negative). This is because the cold stop is inside the instrument, and the angle of the instrument rotator is a combination of parallactic angle and pupil rotation. The cold stop just needs to negate the parallactic angle caused by the insturment rotator. This value may include an offset if the observer has requested a particular zenith direction in the image.*
-
-          *Discussion:  If we need to support pupil rotation tracking mode (= fixed pupil mode, or ADI mode) in the future, this value should be the zenith direction in the image specified by the observer. This should be fixed during the observation because the instrument rotator is supposed to compensate the pupil rotation.*
+          *Discussion: For conventional field rotation tracking observations, this value will be the same as the parallactic angle (or its negative) plus the position angle. However, this attribute can be just the position angle or the sum of the pupil rotation and the position angle in different tracking modes. See "2.1.2 IRIS Celestial Tracking Modes" in TMT.SEN.ICD.13.002 for more details.*
 """
           type          = double
           minimum       = -180

--- a/iris/publish-model.conf
+++ b/iris/publish-model.conf
@@ -11,12 +11,12 @@ publish {
 
        The entire event is published atomically so that all published subcomponents are synchronized.
 
-       *Discussion: This event is published at 1 Hz. If IRIS needs finer time granuality to frequently control the mechanisms in their control loops, IRIS software should perform interpolation internally using the latest event and/or the past events.*
+       *Discussion: This event is published at 2 Hz. If IRIS needs finer time granuality to frequently control the mechanisms in their control loops, IRIS software should perform interpolation internally using the latest event and/or the past events.*
 
-       *Discussion: This event should be published nominally 3 seconds (and, at least, 2 seconds) before the time indicated by the "timestamp" attribute.*
+       *Discussion: This event should be published > 1 second (TBC) before the time indicated by the "timestamp" attribute.*
        """
-      maxRate           = 1
-      minRate           = 1
+      maxRate           = 2
+      minRate           = 2
       archive           = true
       attributes        = [
         {
@@ -35,7 +35,7 @@ publish {
           name          = orientation
           description   = """Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of the FCRS<sub>IRIS-ROT</sub>.
 
-          *Discussion: For conventional field rotation tracking observations, this value is the same as the parallactic angle (or its negative) plus the position angle. However, this attribute can be just the position angle or the sum of the pupil rotation and the position angle in different tracking modes. See "2.1.2 IRIS Celestial Tracking Modes" in TMT.SEN.ICD.13.002 for more details.*
+          *Discussion: For conventional field rotation tracking observations, this value is the same as the parallactic angle (or its negative) plus the position angle. However, this attribute can be a different value in other tracking modes. See "2.1.2 IRIS Celestial Tracking Modes" in TMT.SEN.ICD.13.002 for more details.*
 """
           type          = double
           minimum       = -180
@@ -398,21 +398,20 @@ publish {
     }
 
     {
-      name              = coldStopMaskAngle
+      name              = pupilRotation
       description       = """
-      The TCS publishes the timestamped future cold stop mask angle.
+      The TCS publishes the timestamped future pupil rotation angle in FCRS<sub>IRIS-ROT</sub>.
 
-       *Discussion: This event should be published nominally 3 seconds (and, at least, 2 seconds) before the time indicated by the "timestamp" attribute.*
+       *Discussion: This event should be published > 1 second (TBC) before the time indicated by the "timestamp" attribute.*
       """
-      minRate           = 10
       maxRate           = 20
       archive           = true
       attributes        = [
         {
-          name          = coldStopMaskAngle
+          name          = pupilRotation
           description   = """Future IRIS pupil rotation angle in the X,Y plane of the FCRS<sub>IRIS-ROT</sub> that will be valid at the time indicated bythe "timestamp" attribute.
 
-          *Discussion: For conventional field rotation tracking observations, this value will be the same as the parallactic angle (or its negative) plus the position angle. However, this attribute can be just the position angle or the sum of the pupil rotation and the position angle in different tracking modes. See "2.1.2 IRIS Celestial Tracking Modes" in TMT.SEN.ICD.13.002 for more details.*
+          *Discussion: For conventional field rotation tracking observations, this value will be the same as the parallactic angle (or its negative) plus the position angle. However, this attribute can be a different value in other tracking modes. See "2.1.2 IRIS Celestial Tracking Modes" in TMT.SEN.ICD.13.002 for more details.*
 """
           type          = double
           minimum       = -180
@@ -428,32 +427,6 @@ publish {
           name          = trackID
           description   = "Unique TCS target ID that is incremented (with rollover) each time the TCS is instructed to move to a new target."
           type          = long
-        }
-        {
-          name          = timestamp
-          description   = "Time when valid (units and epoch are TBD)"
-          units         = mjd
-          type          = long
-        }
-      ]
-    }
-
-    {
-      name              = pupilRotation
-      description       = """
-      The TCS publishes the timestamped future pupil rotation angle.
-      """
-      maxRate           = 20
-      archive           = true
-      attributes        = [
-        {
-          name          = pupilRotation
-          description   = """Future IRIS pupil rotation angle in the X,Y plane of the FCRS<sub>IRIS-ROT</sub> that will be valid at the time indicated bythe "timestamp" attribute.
-"""
-          type          = double
-          minimum       = -180
-          maximum       = 180
-          units         = degrees
         }
         {
           name          = timestamp


### PR DESCRIPTION
This pull request includes the following changes:
- Added new event _coldStopMaskAngle_. This was previously _pupilRotation_, but it was renamed because the cold stop mask angle can be different from the pupil rotation in special tracking modes (e.g., M1 tracking and DM0 tracking modes).
- The old _pupilRotation_ remains because the IRIS DRS subscribes to it. Tracking attributes (_pointingstate_ and _trackID_) are now removed because _pupilRotation_ won't be used for tracking anymore.
- Revised the description of _imgAtmDispersion_ and _instrumentRotatorAngle_ to clarify that the TCS sends the correct angle taking into account the current tracking mode (normal tracking mode, M1 tracking mode or DM0 tracking mode).
- Revised the description of _imgAtmDispersion_ and _coldStopMaskAngle_ because the IRIS software needs those demands 3 seconds before the time indicated by the _timestamp_ attribute.